### PR TITLE
Set Package as ESM module by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-time-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Aerie Time Utility",
   "description": "Provides helper functions to process time values within the Aerie ecosystem",
   "author": "NASA/JPL",
@@ -12,6 +12,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "require": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./timeUtils";
+export * from "./timeUtils.js";
 export * from "./constants/time.js";
 export * from "./types/time.js";
 export * from "./enums/time.js";


### PR DESCRIPTION
Didn't set this package as a ESM model so it is being used as a commonjs package by default.  